### PR TITLE
Fix the byte-compile warning

### DIFF
--- a/kele.el
+++ b/kele.el
@@ -28,6 +28,7 @@
 (require 'plz)
 (require 'subr-x)
 (require 'yaml)
+(require 'json)
 
 (defgroup kele nil
   "Integration constructs for Kubernetes."


### PR DESCRIPTION
```
In end of data:
kele.el:385:40: Warning: the function ‘json-read’ is not known to be defined.
```