### PR TITLE
Implement rudimentary integration testing scaffold

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,11 @@ jobs:
     env:
       EMACS_VERSION: ${{ matrix.emacs_version }}
     steps:
+      - name: Setup integration test cluster
+        id: kind
+        uses: helm/kind-action@v1.4.0
+        with:
+          config: $GITHUB_WORKSPACE/tests/test-cluster.yaml
       - name: Setup Emacs
         uses: purcell/setup-emacs@master
         with:
@@ -46,12 +51,6 @@ jobs:
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
         run: |
           make testall
-
-      - name: Setup integration test cluster
-        id: kind
-        uses: helm/kind-action@v1.4.0
-        with:
-          config: tests/test-cluster.yaml
 
       - name: Run integration tests
         if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,5 +52,5 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           env_vars: EMACS_VERSION
-          files: ./coverage/lcov-buttercup.info
+          files: ./coverage/unit/lcov-buttercup.info,./coverage/integration/lcov-buttercup.info
           fail_ci_if_error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Run integration tests
         if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'
         run: |
-          make integration-test
+          cask exec buttercup -L . tests/integration/
 
       - name: Upload coverage
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
     env:
       EMACS_VERSION: ${{ matrix.emacs_version }}
     steps:
+      - uses: actions/checkout@v3
       - name: Setup integration test cluster
         id: kind
         uses: helm/kind-action@v1.4.0
@@ -39,7 +40,6 @@ jobs:
         uses: conao3/setup-cask@master
         with:
           version: "snapshot"
-      - uses: actions/checkout@v3
       - name: Install
         id: install
         continue-on-error: ${{ matrix.ignore_error != '' && matrix.ignore_error }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,8 @@ jobs:
         id: kind
         uses: helm/kind-action@v1.4.0
         with:
-          config: $GITHUB_WORKSPACE/tests/test-cluster.yaml
+          config: tests/test-cluster.yaml
+          cluster_name: kele-test-cluster0
       - name: Setup Emacs
         uses: purcell/setup-emacs@master
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
         id: kind
         uses: helm/kind-action@v1.4.0
         with:
-          config: ./tests/test-cluster.yaml
+          config: tests/test-cluster.yaml
 
       - name: Run integration tests
         if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
           config: ./tests/test-cluster.yaml
 
       - name: Run integration tests
-        if: steps.kind.outcome == 'success' and steps.kind.conclusion == 'success'
+        if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'
         run: |
           make integration-test
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,13 +20,6 @@ jobs:
     env:
       EMACS_VERSION: ${{ matrix.emacs_version }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup integration test cluster
-        id: kind
-        uses: helm/kind-action@v1.4.0
-        with:
-          config: tests/test-cluster.yaml
-          cluster_name: kele-test-cluster0
       - name: Setup Emacs
         uses: purcell/setup-emacs@master
         with:
@@ -40,6 +33,7 @@ jobs:
         uses: conao3/setup-cask@master
         with:
           version: "snapshot"
+      - uses: actions/checkout@v3
       - name: Install
         id: install
         continue-on-error: ${{ matrix.ignore_error != '' && matrix.ignore_error }}
@@ -53,6 +47,12 @@ jobs:
         run: |
           make testall
 
+      - name: Setup integration test cluster
+        id: kind
+        uses: helm/kind-action@v1.4.0
+        with:
+          config: tests/test-cluster.yaml
+          cluster_name: kele-test-cluster0
       - name: Run integration tests
         if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,10 +42,21 @@ jobs:
           cask build --verbose
           make compile
 
-      - name: Test
+      - name: Run unit and static tests
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
         run: |
           make testall
+
+      - name: Setup integration test cluster
+        id: kind
+        uses: helm/kind-action@v1.4.0
+        with:
+          config: ./tests/test-cluster.yaml
+
+      - name: Run integration tests
+        if: steps.kind.outcome == 'success' and steps.kind.conclusion == 'success'
+        run: |
+          make integration-test
 
       - name: Upload coverage
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,10 @@ testall: checkdoc package-lint test
 test-cluster-create:
 	kind create cluster --kubeconfig ./tests/kubeconfig.yaml --config ./tests/test-cluster.yaml
 
-.PHONY: test-cluster-stop
-test-cluster-stop:
-	kind delete cluster --kubeconfig ./tests/kubeconfig.yaml --name kele-test-cluster0
-
 .PHONY: integration-test
-integration-test:
-	cask exec buttercup -L . tests/integration/
+integration-test: test-cluster-create
+	KUBECONFIG=./tests/kubeconfig.yaml cask exec buttercup -L . tests/integration/
 
+.PHONY: test-cluster-stop
+test-cluster-stop: integration-test
+	kind delete cluster --kubeconfig ./tests/kubeconfig.yaml --name kele-test-cluster0

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,14 @@ package-lint:
 .PHONY: test
 test: compile
 	cask clean-elc
-	cask exec buttercup -L . tests/
+	cask exec buttercup -L . tests/unit/
 
 .PHONY: all
 testall: checkdoc package-lint test
 
-.PHONY: fake-cluster
-fake-cluster:
+.PHONY: integration-test
+integration-test:
 	kind create cluster --kubeconfig ./tests/kubeconfig.yaml --config ./tests/test-cluster.yaml
-	kind delete cluster --kubeconfig ./tests/kubeconfig.yaml --name kele-test-cluster
+	cask exec buttercup -L . tests/integration/
+	kind delete cluster --kubeconfig ./tests/kubeconfig.yaml --name kele-test-cluster0
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,15 @@ test: compile
 .PHONY: all
 testall: checkdoc package-lint test
 
+.PHONY: test-cluster-create
+test-cluster-create:
+	kind create cluster --kubeconfig ./tests/kubeconfig.yaml --config ./tests/test-cluster.yaml
+
+.PHONY: test-cluster-stop
+test-cluster-stop:
+	kind delete cluster --kubeconfig ./tests/kubeconfig.yaml --name kele-test-cluster0
+
 .PHONY: integration-test
 integration-test:
-	kind create cluster --kubeconfig ./tests/kubeconfig.yaml --config ./tests/test-cluster.yaml
 	cask exec buttercup -L . tests/integration/
-	kind delete cluster --kubeconfig ./tests/kubeconfig.yaml --name kele-test-cluster0
 

--- a/kele.el
+++ b/kele.el
@@ -159,7 +159,9 @@ If WAIT is non-nil, `kele--proxy-process' will wait for the proxy
 
 (cl-defun kele-kubectl-do (&rest args)
   "Execute kubectl with ARGS."
-  (let ((cmd (append (list kele-kubectl-executable) args)))
+  (let ((cmd (append (list kele-kubectl-executable)
+                     `("--kubeconfig" ,kele-kubeconfig-path)
+                     args)))
     (make-process
      :name (format "kele: %s" (s-join " " cmd))
      :command cmd

--- a/tests/integration/test-integration.el
+++ b/tests/integration/test-integration.el
@@ -6,9 +6,6 @@
 (require 'buttercup)
 
 (describe "config interactions"
-  (before-all
-    (setq kele-kubeconfig-path (f-expand "./tests/kubeconfig.yaml")))
-
   (describe "kele-namespace-switch-for-context"
     (it "switches context properly"
       (kele-context-switch "kind-kele-test-cluster0")

--- a/tests/integration/test-integration.el
+++ b/tests/integration/test-integration.el
@@ -1,0 +1,17 @@
+(load-file "./tests/integration/undercover-init.el")
+
+(require 'async)
+(require 'f)
+(require 'kele)
+(require 'buttercup)
+
+(describe "config interactions"
+  (before-all
+    (setq kele-kubeconfig-path (f-expand "./tests/kubeconfig.yaml")))
+
+  (describe "kele-namespace-switch-for-context"
+    (it "switches context properly"
+      (kele-context-switch "kind-kele-test-cluster0")
+      (kele-namespace-switch-for-context "kind-kele-test-cluster0" "kube-public")
+      (async-wait (kele--update-kubeconfig))
+      (expect (kele-current-namespace) :to-equal "kube-public"))))

--- a/tests/integration/undercover-init.el
+++ b/tests/integration/undercover-init.el
@@ -1,0 +1,6 @@
+(when (require 'undercover nil t)
+  (with-no-warnings
+    (undercover "*.el"
+                (:report-file "./coverage/integration/lcov-buttercup.info")
+                (:report-format 'lcov)
+                (:send-report nil))))

--- a/tests/test-cluster.yaml
+++ b/tests/test-cluster.yaml
@@ -1,6 +1,6 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
-name: kele-test-cluster
+name: kele-test-cluster0
 nodes:
   - role: control-plane
   - role: worker

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -2,7 +2,7 @@
 ;;; Commentary:
 ;;; Code:
 
-(load-file "./tests/undercover-init.el")
+(load-file "./tests/unit/undercover-init.el")
 
 (require 'async)
 (require 'f)

--- a/tests/unit/undercover-init.el
+++ b/tests/unit/undercover-init.el
@@ -1,6 +1,6 @@
 (when (require 'undercover nil t)
   (with-no-warnings
     (undercover "*.el"
-                (:report-file "./coverage/lcov-buttercup.info")
+                (:report-file "./coverage/unit/lcov-buttercup.info")
                 (:report-format 'lcov)
                 (:send-report nil))))


### PR DESCRIPTION
Closes #33 and #25.

This commit introduces a simple integration testing setup that spins up a [Kind](https://kind.sigs.k8s.io) cluster, performs tests against it, and tears the Kind cluster down afterwards. It also sets up corresponding CI configurations.