### PR TITLE
CI: retry integration tests on timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,7 @@ jobs:
           max_attempts: 3
           retry_on: timeout
           timeout_minutes: 3
+          on_retry_command: rm ./coverage/integration/lcov-buttercup.info
           command: |
             cask exec buttercup -L . tests/integration/
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,8 +62,8 @@ jobs:
           max_attempts: 3
           retry_on: timeout
           timeout_minutes: 3
-        run: |
-          cask exec buttercup -L . tests/integration/
+          command: |
+            cask exec buttercup -L . tests/integration/
 
       - name: Upload coverage
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           # at least one test is flaky. See #40
-          max_attempts: 3
+          max_attempts: 6
           retry_on: timeout
           timeout_minutes: 3
           on_retry_command: rm ./coverage/integration/lcov-buttercup.info

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,8 +53,15 @@ jobs:
         with:
           config: tests/test-cluster.yaml
           cluster_name: kele-test-cluster0
+
       - name: Run integration tests
         if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'
+        uses: nick-fields/retry@v2
+        with:
+          # at least one test is flaky. See #40
+          max_attempts: 3
+          retry_on: timeout
+          timeout_minutes: 3
         run: |
           cask exec buttercup -L . tests/integration/
 


### PR DESCRIPTION
Until we can properly fix #40, we put in a retry for the integration test to mitigate flakiness.