### PR TITLE
Implement naive `get`-ing of namespaced resource

### DIFF
--- a/kele.el
+++ b/kele.el
@@ -584,6 +584,37 @@ The cache has a TTL as defined by
    #'kele--clear-namespaces-for-context
    context))
 
+(define-error 'kele-request-error "Kele failed in querying the Kubernetes API")
+
+(cl-defun kele--get-namespaced-resource (group version kind name &key context namespace)
+  "Get resource according to GROUP, VERSION, KIND, and NAME.
+
+KIND should be the plural form of the kind's name.
+
+If GROUP is nil, look up KIND in the core API group.
+
+If CONTEXT is nil, use the current namespace.
+
+If NAMESPACE is nil, use the default namespace of the given
+CONTEXT.
+
+Note that this function does *not* handle resource kinds that are
+not namespaced."
+  (-let* ((context (or context (kele-current-context-name)))
+          (namespace (or namespace (kele--default-namespace-for-context context)))
+          (url-gv (if (not group)
+                      (format "api/%s" version)
+                    (format "apis/%s/%s" group version)))
+          (url-ns (format "namespaces/%s" namespace))
+          (url-res (format "%s/%s" kind name))
+          (url-all (s-join "/" `(,url-gv ,url-ns ,url-res)))
+          ((&alist 'port port) (kele--ensure-proxy context))
+          (url (format "http://localhost:%s/%s" port url-all)))
+    (condition-case err
+        (plz 'get url :as #'json-read)
+      (error (signal 'kele-request-error (error-message-string err)))))) ;
+
+
 (defvar kele--context-keymap nil
   "Keymap for actions on Kubernetes contexts.
 

--- a/tests/integration/test-integration.el
+++ b/tests/integration/test-integration.el
@@ -23,6 +23,20 @@
               "kube-system"
               "local-path-storage"))))
 
+(describe "kele--get-namespaced-resource"
+  :var (retval)
+  (it "retrieves the resource as an alist"
+    (setq retval (kele--get-namespaced-resource "apps" "v1" "deployments" "coredns"
+                                                :context "kind-kele-test-cluster0"
+                                                :namespace "kube-system"))
+
+    (expect (let-alist retval .metadata.name) :to-equal "coredns"))
+  (it "returns an error if the resource is nonsense or does not exist"
+    (expect (kele--get-namespaced-resource "hello" "v1" "salaries" "mine"
+                                           :context "kind-kele-test-cluster0"
+                                           :namespace "kube-system")
+            :to-throw 'kele-request-error)))
+
 (describe "kele--proxy-process"
   (it "successfully creates a proxy process"
     (kele--proxy-process "kind-kele-test-cluster0" :port 9999 :wait t :read-only t)


### PR DESCRIPTION
Contributes to #45.

This commit introduces a very naive function to `get` (as in `kubectl get`) a namespaced resource. It has no completion support, no interactive support at all, and has no caching support whatsoever.

It's a start.