### PR TITLE
`kele-get`: Output buffer only shows namespace if needed

### DIFF
--- a/docs/references/changelog.md
+++ b/docs/references/changelog.md
@@ -19,6 +19,11 @@ versioning][semver].
 - Added a custom variable `kele-filtered-fields` with which you can routinely
   filter out resource fields from display in `kele-get`
 
+### Fixed
+
+- Fixed an issue where `kele-get` results buffer incorrectly prints namespace
+  for un-namespaced resources as `nil`
+
 ### Changed
 
 - `kele-get` completion for the resource type now only returns resources that

--- a/kele.el
+++ b/kele.el
@@ -686,7 +686,10 @@ object.
 
 RETRIEVAL-TIME denotes the time at which RESOURCE was retrieved.
 "
-  resource context namespace retrieval-time)
+  resource
+  context
+  namespace
+  retrieval-time)
 
 (cl-defun kele--get-resource (kind name &key group version context namespace)
   "Get resource KIND by NAME.
@@ -859,11 +862,13 @@ context and namespace in its name."
                            t)))
   (let* ((buf-name (concat " *kele: "
                            (if (kele--resource-container-p object)
-                                 (format "%s(%s): "
-                                         (kele--resource-container-context
-                                          object)
-                                         (kele--resource-container-namespace
-                                          object)))
+                               (concat
+                                (kele--resource-container-context object)
+                                (and (kele--resource-container-namespace object)
+                                     (format "(%s)"
+                                             (kele--resource-container-namespace
+                                              object)))
+                                ": "))
                            (let-alist (if (kele--resource-container-p object)
                                           (kele--resource-container-resource object)
                                         object)

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -395,7 +395,14 @@ metadata:
                               :resource fake-obj
                               :context "fake-context"
                               :namespace "fake-namespace"))
-        (expect (-map #'buffer-name (buffer-list)) :to-contain " *kele: fake-context(fake-namespace): FakeKind/fake-name*")))
+        (expect (-map #'buffer-name (buffer-list)) :to-contain " *kele: fake-context(fake-namespace): FakeKind/fake-name*"))
+      (describe "when the resource is not namespaced"
+        (it "buffer name only shows context, kind, and name"
+          (kele--render-object (kele--resource-container-create
+                                :resource fake-obj
+                                :context "fake-context"
+                                :namespace nil))
+          (expect (-map #'buffer-name (buffer-list)) :to-contain " *kele: fake-context: FakeKind/fake-name*"))))
     (describe "when input is regular alist"
       (it "buffer name only has kind and name"
         (kele--render-object fake-obj)


### PR DESCRIPTION
Fixes #85.