### PR TITLE
Define `kele-mode-map`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,38 +29,12 @@ e.g. [Embark], that you can take advantage of in your own configs.
 
 ## Getting Started
 
-=== "Use-package + Straight"
-
-    ```emacs-lisp
-    (use-package kele
-      :straight t
-      :config
-      (kele-mode 1))
-    ```
-
-=== "Use-package"
-
-    ```emacs-lisp
-    (use-package kele
-      :config
-      (kele-mode 1))
-    ```
-
-=== "Straight"
-
-    ```emacs-lisp
-    (straight-use-package kele)
-    (kele-mode 1)
-    ```
-
-=== "The Hard Way"
-
-    Clone this repository and all dependencies and put them in your load-path.
-
-    ```emacs-lisp
-    (require 'kele)
-    (kele-mode 1)
-    ```
+```emacs-lisp
+(use-package kele
+  :config
+  (kele-mode 1)
+  (bind-key (kbd "s-k") kele-command-map kele-mode-map))
+```
 
 ## Design Ethos
 

--- a/kele.el
+++ b/kele.el
@@ -1127,9 +1127,6 @@ Only populated if Embark is installed.")
   (interactive (list (kele-current-context-name)))
   (transient-setup 'kele-context nil nil :scope context))
 
-;; TODO: Define a `kele-mode-map' and a `kele-command-map', w/ instructions for
-;; how to bind, say, `s-k' w/i former to latter
-
 (provide 'kele)
 
 ;;; kele.el ends here

--- a/kele.el
+++ b/kele.el
@@ -1085,10 +1085,21 @@ Only populated if Embark is installed.")
       (with-suppressed-warnings ((free-vars awesome-tray-module-alist))
         (delete kele--awesome-tray-module awesome-tray-module-alist))))
 
+(defvar kele-mode-map (make-sparse-keymap)
+  "Keymap for Kele mode.")
+
+(defvar kele-command-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "c") #'kele-context)
+    (define-key map (kbd "?") #'kele-dispatch)
+    map)
+  "Keymap for Kele commands.")
+
 ;;;###autoload
 (define-minor-mode kele-mode
   "Minor mode to enable listening on Kubernetes configs."
   :global t
+  :keymap kele-mode-map
   :group 'kele
   :lighter nil
   (if (not kele-mode)
@@ -1115,6 +1126,9 @@ Only populated if Embark is installed.")
                                                 'face 'warning))))]
   (interactive (list (kele-current-context-name)))
   (transient-setup 'kele-context nil nil :scope context))
+
+;; TODO: Define a `kele-mode-map' and a `kele-command-map', w/ instructions for
+;; how to bind, say, `s-k' w/i former to latter
 
 (provide 'kele)
 


### PR DESCRIPTION
We draw inspiration from Projectile to define a `kele-mode-map` and a corresponding `kele-command-map`. This will allow users to bind a single prefix key, e.g. `(kbd "s-k")`, to gain access to a spread of relevant Transient-based commands, e.g. `kele-context`.