### PR TITLE
`kele-resource`: `context` infix resets `namespace` infix

### DIFF
--- a/kele.el
+++ b/kele.el
@@ -1159,8 +1159,8 @@ scope.")
 On each invocation, calls OBJ's `fn' field with the prefix's
 scope and NEW-VALUE."
   (cl-call-next-method obj new-value)
-  ;; FIXME: This should allow :fn to not be set
-  (funcall (oref obj fn) (oref transient--prefix scope) new-value))
+  (when (slot-boundp obj 'fn)
+    (funcall (oref obj fn) (oref transient--prefix scope) new-value)))
 
 (defclass kele--transient-infix-resetter (transient-option)
   ((resettees
@@ -1168,7 +1168,8 @@ scope and NEW-VALUE."
     :initform nil
     :type list
     :documentation
-    "List of arguments on the same prefix to reset when this one changes.")))
+    "List of arguments on the same prefix to reset when this one changes."))
+  "A Transient infix that can also \"reset\" any of its peer infixes.")
 
 (cl-defmethod transient-infix-set ((obj kele--transient-infix-resetter) val)
   "Set the infix VAL for OBJ.
@@ -1230,7 +1231,6 @@ Defaults to the currently active context as set in
 (transient-define-prefix kele-resource (group-version kind)
   ["Arguments"
    (kele--context-infix)
-   ;; FIXME(#117): Reset namespace if context changes
    (kele--namespace-infix)]
 
   ["Actions"

--- a/kele.el
+++ b/kele.el
@@ -1156,12 +1156,10 @@ scope.")
 (cl-defmethod transient-infix-set ((obj kele--transient-scope-mutator) new-value)
   "Set the infix NEW-VALUE while modifying the current prefix's scope.
 
-Uses OBJ's `scope-key' field as the key for the current prefix's
-scope.
-
-Assumes that the prefix's scope is an alist.  Assumes that the
-key is already present in the alist."
+On each invocation, calls OBJ's `fn' field with the prefix's
+scope and NEW-VALUE."
   (cl-call-next-method obj new-value)
+  ;; FIXME: This should allow :fn to not be set
   (funcall (oref obj fn) (oref transient--prefix scope) new-value))
 
 (defclass kele--transient-infix-resetter (transient-option)
@@ -1173,8 +1171,10 @@ key is already present in the alist."
     "List of arguments on the same prefix to reset when this one changes.")))
 
 (cl-defmethod transient-infix-set ((obj kele--transient-infix-resetter) val)
-  "Set the infix VAL while resetting any specified peer arguments
-on the same prefix."
+  "Set the infix VAL for OBJ.
+
+Also resets any specified peer arguments on the same prefix that
+  match any element of `:resettees' on OBJ."
   (cl-call-next-method obj val)
   (dolist (arg (oref obj resettees))
     (when-let ((obj (cl-find-if (lambda (obj)

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -486,4 +486,17 @@ metadata:
   (it "sets the value of the actual infix properly"
     (expect (oref infix value) :to-equal "foo")))
 
+(describe "kele--transient-infix-resetter"
+  :var (infix other0 other1)
+  (before-each
+    (spy-on 'transient-init-value)
+    (setq other0 (transient-option :argument "--foo"))
+    (setq other1 (transient-option :argument "--bar"))
+    (setq transient--suffixes `(,other0 ,other1)))
+  (it "re-initializes the value of the specified infix"
+    (transient-infix-set
+     (kele--transient-infix-resetter :resettees '("--foo") :argument "--whatever=")
+     "value")
+    (expect 'transient-init-value :to-have-been-called-with other0)))
+
 ;;; test-kele.el ends here


### PR DESCRIPTION
Fixes #117.