### PR TITLE
fix: pull `kele-resource::g` out into dedicated suffix def'n

### DIFF
--- a/docs/references/changelog.md
+++ b/docs/references/changelog.md
@@ -28,6 +28,9 @@ versioning][semver].
 - Fixed a bug where force-enabling or force-disabling `kele-mode` (via either
   `(kele-mode 1)` or `(kele-mode -1)`) when `kele-mode` is already active or
   inactive (respectively) resulted in errors
+- Fixed an issue where attempting to invoke `s-k <resource name> g` sometimes
+  results in the following error: `transient-setup: Suffix
+  transient:kele-resource::command is not defined or autoloaded as a command`
 
 ### Changed
 

--- a/kele.el
+++ b/kele.el
@@ -1437,7 +1437,7 @@ Otherwise, returns the current context name from kubeconfig."
       value
     (kele-current-context-name)))
 
-(cl-defun kele--get-namespace-arg ()
+(cl-defun kele--get-namespace-arg (&key use-default group-version kind)
   "Get the value to use for Kubernetes namespace.
 
 First checks the current Transient command's arguments if set.
@@ -1447,7 +1447,15 @@ kubeconfig."
             (args (transient-args cmd))
             (value (transient-arg-value "--namespace=" args)))
       value
-    (kele--default-namespace-for-context (kele--get-context-arg))))
+    (if (or (not (and group-version kind))
+            use-default)
+        (kele--default-namespace-for-context (kele--get-context-arg))
+      (if (not (kele--resource-namespaced-p
+                kele--global-discovery-cache
+                group-version
+                kind))
+          nil
+        (completing-read "Namespace: " (kele--get-namespaces (kele--get-context-arg)))))))
 
 (cl-defun kele--get-groupversion-arg (&optional kind)
   "Get the group-version to use for a command.
@@ -1564,6 +1572,31 @@ if it's set.  Otherwise, prompts user for input."
                        (kele--get-resource-types-for-context
                         (kele--get-context-arg)))))
 
+(transient-define-suffix kele--get ()
+  :key "g"
+  :description
+  (lambda ()
+    (--> (oref transient--prefix scope)
+         (alist-get 'kind it)
+         (propertize it 'face 'warning)
+         (format "Get a single %s" it)))
+  (interactive)
+  (-let* ((kind (kele--get-kind-arg))
+          ((group version) (kele--groupversion-split (kele--get-groupversion-arg)))
+          (ns (kele--get-namespace-arg
+               :group-version (kele--get-groupversion-arg)
+               :kind kind
+               :use-default nil))
+          (cands (kele--fetch-resource-names group version kind
+                                             :namespace ns
+                                             :context (kele--get-context-arg)))
+          (name (completing-read "Name: " (-cut kele--resources-complete <> <> <> :cands cands))))
+    (kele-get kind name
+              :group group
+              :version version
+              :namespace ns
+              :context (kele--get-context-arg))))
+
 (transient-define-prefix kele-resource (group-versions kind)
   ["Arguments"
    (kele--context-infix)
@@ -1571,27 +1604,7 @@ if it's set.  Otherwise, prompts user for input."
    (kele--namespace-infix)]
 
   ["Actions"
-   ("g"
-    :command
-    (lambda ()
-      (interactive)
-      (-let* ((kind (kele--get-kind-arg))
-              ((group version) (kele--groupversion-split (kele--get-groupversion-arg)))
-              (cands (kele--fetch-resource-names group version kind
-                                                 :namespace (kele--get-namespace-arg)
-                                                 :context (kele--get-context-arg)))
-              (name (completing-read "Name: " (-cut kele--resources-complete <> <> <> :cands cands))))
-        (kele-get kind name
-                  :group group
-                  :version version
-                  :namespace namespace
-                  :context context)))
-    :description
-    (lambda ()
-      (--> (oref transient--prefix scope)
-           (alist-get 'kind it)
-           (propertize it 'face 'warning)
-           (format "Get a single %s" it))))
+   (kele--get)
    (kele-list)]
 
   (interactive (let* ((context (kele-current-context-name))

--- a/kele.el
+++ b/kele.el
@@ -1452,19 +1452,20 @@ In order of priority, this function attempts the following:
   namespaced, return nil;
 
 - Otherwise, ask the user to select a namespace."
-  (if-let* ((cmd transient-current-command)
-            (args (transient-args cmd))
-            (value (transient-arg-value "--namespace=" args)))
-      value
-    (if (or (not (and group-version kind))
-            use-default)
-        (kele--default-namespace-for-context (kele--get-context-arg))
-      (if (not (kele--resource-namespaced-p
-                kele--global-discovery-cache
-                group-version
-                kind))
-          nil
-        (completing-read "Namespace: " (kele--get-namespaces (kele--get-context-arg)))))))
+  (let ((transient-arg-maybe (->> transient-current-command
+                                  (transient-args)
+                                  (transient-arg-value "--namespace="))))
+    (cond
+     (transient-arg-maybe transient-arg-maybe)
+     ((or (not (and group-version kind)) use-default)
+      (kele--default-namespace-for-context (kele--get-context-arg)))
+     ((not (kele--resource-namespaced-p
+            kele--global-discovery-cache
+            group-version
+            kind))
+      nil)
+     (t (completing-read "Namespace: "
+                         (kele--get-namespaces (kele--get-context-arg)))))))
 
 (cl-defun kele--get-groupversion-arg (&optional kind)
   "Get the group-version to use for a command.

--- a/kele.el
+++ b/kele.el
@@ -1440,9 +1440,18 @@ Otherwise, returns the current context name from kubeconfig."
 (cl-defun kele--get-namespace-arg (&key use-default group-version kind)
   "Get the value to use for Kubernetes namespace.
 
-First checks the current Transient command's arguments if set.
-Otherwise, returns the current context's default namespace from
-kubeconfig."
+In order of priority, this function attempts the following:
+
+- If we are currently in a Transient command; if so, pull the
+  `--namespace=`' argument from it;
+
+- If USE-DEFAULT is non-nil, use the default namespace for the context argument
+  (from `kele--get-context-arg');
+
+- If the resource type specified by GROUP-VERSION and KIND is not
+  namespaced, return nil;
+
+- Otherwise, ask the user to select a namespace."
   (if-let* ((cmd transient-current-command)
             (args (transient-args cmd))
             (value (transient-arg-value "--namespace=" args)))

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -575,7 +575,7 @@ metadata:
     (before-each
       (setq transient-current-command nil))
     (it "retrieves the default namespace of the current context"
-      (expect (kele--get-namespace-arg) :to-equal "development-namespace"))))
+      (expect (kele--get-namespace-arg :use-default t) :to-equal "development-namespace"))))
 
 (describe "kele--get-kind-arg"
   (describe "when called in a Transient suffix"

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -572,10 +572,28 @@ metadata:
     (it "retrieves from the suffix's arguments"
       (expect (kele--get-namespace-arg) :to-equal "foo")))
   (describe "when called outside of a Transient"
-    (before-each
-      (setq transient-current-command nil))
-    (it "retrieves the default namespace of the current context"
-      (expect (kele--get-namespace-arg :use-default t) :to-equal "development-namespace"))))
+    (describe "when USE-DEFAULT is non-nil"
+      (before-each
+        (setq transient-current-command nil))
+      (it "retrieves the default namespace of the current context"
+        (expect (kele--get-namespace-arg :use-default t) :to-equal "development-namespace")))
+
+    (describe "when USE-DEFAULT is nil"
+      (describe "when GROUP-VERSION and KIND is not namespaced"
+        (before-each
+          (spy-on 'kele--resource-namespaced-p :and-return-value nil))
+        (it "returns nil"
+          (expect (kele--get-namespace-arg :group-version "apps/v1" :kind "foo")
+                  :not :to-be-truthy)))
+
+      (describe "when GROUP-VERSION and KIND are namespaced"
+        (before-each
+          (spy-on 'kele--resource-namespaced-p :and-return-value t)
+          (spy-on 'completing-read))
+        (it "prompts user for namespace selection"
+          (spy-on 'kele--get-namespaces)
+          (kele--get-namespace-arg :group-version "apps/v1" :kind "foo")
+          (expect 'completing-read :to-have-been-called))))))
 
 (describe "kele--get-kind-arg"
   (describe "when called in a Transient suffix"


### PR DESCRIPTION
Fixes #139.

The suffix definition for `kele-resource::g` is getting unwieldy and running into oddball issues relating (presumably) to autoload. In lieu of figuring out what the actual underlying cause is, we simply bubble the suffix out into a "proper" definition with `transient-define-suffix`, which seems to fix the issue.