### PR TITLE
Consolidate `kele-get` and its analogous Transient suffix

### DIFF
--- a/kele.el
+++ b/kele.el
@@ -1532,7 +1532,7 @@ instead of \"pod.\""
          (format "Get a single %s" it)))
   (interactive
    (-let* ((kind (kele--get-kind-arg))
-           (gv (kele--get-groupversion-arg))
+           (gv (kele--get-groupversion-arg kind))
            ((group version) (kele--groupversion-split gv))
            (ns (kele--get-namespace-arg
                 :group-version gv

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -640,11 +640,6 @@ metadata:
 
     (kele-list-get)
     (expect 'kele-get :to-have-been-called-with
-            "kind"
-            "name"
-            :group "group"
-            :version "v1"
-            :context "context"
-            :namespace "namespace")))
+            "context" "namespace" "group/v1" "kind" "name")))
 
  ;;; test-kele.el ends here


### PR DESCRIPTION
With #143 we pulled the "get resource by name" suffix out into a dedicated definition block. At this point, users can reasonably use the suffix as both a Transient suffix and an interactive function. Keeping an entirely separate interactive analogue of this logic -- which the former simply calls into -- is no longer necessary.

This PR "promotes" the Transient suffix to the canonical interactive entrypoint to resource-fetching, removing the existing `kele-get` standalone interactive function entirely.