### PR TITLE
Fold kubeconfig cache into comprehensive "kache"

### DIFF
--- a/kele.el
+++ b/kele.el
@@ -241,35 +241,6 @@ Key is the host name and the value is a list of all the
 A class for loading a Kubernetes discovery cache and keeping it
 in sync with the filesystem.")
 
-(defclass kele--kubeconfig-cache ()
-  ((contents
-    :documentation "The loaded kubeconfig contents.")
-   (filewatch-id
-    :documentation "The ID of the file watcher.")
-   (update-in-progress
-    :documentation "Flag denoting whether an update is in progress."
-    :initform nil))
-  "Track the kubeconfig cache.
-
-A class for loading kubeconfig contents and keeping them in sync
-with the filesystem.")
-
-(cl-defmethod kele--wait ((cache kele--kubeconfig-cache)
-                          &key
-                          (count 10)
-                          (wait 1)
-                          (timeout 100)
-                          (msg "Waiting for kubeconfig update to finish..."))
-  "Wait for CACHE to finish updating.
-
-COUNT, WAIT, and TIMEOUT are as defined in `kele--retry'.
-
-MSG is the progress reporting message to display."
-  (when (oref cache update-in-progress)
-    (kele--with-progress msg
-      (kele--retry (lambda () (not (oref cache update-in-progress)))
-                   :count count :wait wait :timeout timeout))))
-
 (defun kele--get-host-for-context (&optional context)
   "Get host for CONTEXT."
   (let* ((server (let-alist (kele--context-cluster (or context (kele-current-context-name)))
@@ -388,24 +359,55 @@ If BOOTSTRAP is non-nil, perform an initial read."
 
 This is separate from `kele-mode' to ensure that activating
 `kele-mode' is idempotent.")
-(defvar kele--global-kubeconfig-cache (kele--kubeconfig-cache))
-(defvar kele--global-discovery-cache (kele--discovery-cache))
 
-(cl-defmethod kele--cache-stop ((cache kele--kubeconfig-cache))
-  "Stop watching `kele-kubeconfig-path' for contents to write to CACHE."
-  (file-notify-rm-watch (oref cache filewatch-id)))
 
-(cl-defmethod kele--cache-update ((cache kele--kubeconfig-cache) &optional _)
-  "Update CACHE with the values from `kele-kubeconfig-path'.
+(defclass kele--kache ()
+  ((discovery-contents
+    :documentation
+    "Alist mapping contexts to the discovered APIs.
+
+Key is the host name and the value is a list of all the
+   APIGroupLists and APIResourceLists found in said cache.")
+
+   (kubeconfig-contents
+    :documentation "The loaded kubeconfig contents.")
+
+   (update-in-progress
+    :documentation "Flag denoting whether a kubeconfig update is in progress."
+    :initform nil)
+
+   (discovery-refresh-interval
+    :documentation
+    "Interval at which a given clsuters' discovery cache should be
+    polled from the filesystem.
+
+Generally, this should be the same as
+`kele-discovery-refresh-interval'.")
+
+   (kubeconfig-watch-id
+    :documentation
+    "The ID of the watcher on the kubeconfig.")
+
+   (cluster-timers
+    :documentation
+    "Alist mapping cluster addresses to their polling timer processes."))
+  "A joint kubeconfig + discovery cache.
+
+`kele--kache' (the \"kache\") attaches a file-watcher to the file at
+kubeconfig-path and creates timer-based update hooks to the corresponding
+sub-directories in the discovery-cache-path according to ")
+
+(cl-defmethod kele--kubeconfig-update ((kache kele--kache) &optional _)
+  "Read the kubeconfig file for KACHE.
 
 This is done asynchronously.  To wait on the results, pass the
 retval into `async-wait'."
-  (let* ((progress-reporter (make-progress-reporter "Pulling kubeconfig contents..."))
+(let* ((progress-reporter (make-progress-reporter "Pulling kubeconfig contents..."))
          (func-complete (lambda (config)
-                          (oset cache contents config)
-                          (oset cache update-in-progress nil)
+                          (oset kache kubeconfig-contents config)
+                          (oset kache update-in-progress nil)
                           (progress-reporter-done progress-reporter))))
-    (oset cache update-in-progress t)
+    (oset kache update-in-progress t)
     (async-start `(lambda ()
                     ;; TODO: How to just do all of these in one fell swoop?
                     (add-to-list 'load-path (file-name-directory ,(locate-library "yaml")))
@@ -420,19 +422,54 @@ retval into `async-wait'."
                                        :sequence-type 'list))
                  func-complete)))
 
-(cl-defmethod kele--cache-start ((cache kele--kubeconfig-cache) &key bootstrap)
-  "Start watching `kele-kubeconfig-path' for CACHE.
+(cl-defmethod kele--cache-update ((kache kele--kache) &optional _)
+  "Update the KACHE.
 
-If BOOTSTRAP is non-nil, will perform an initial load of the
-contents."
-  (oset cache
-        filewatch-id
+This reads the kubeconfig contents and starts/stops per-cluster
+discovery cache poll timers according to what's present in the
+kubeconfig file.
+
+This is done asynchronously.  To wait on the results, pass the
+retval into `async-wait'."
+  (kele--kubeconfig-update kache))
+
+(cl-defmethod kele--cache-stop ((kache kele--kache))
+  "Stop watching `kele-kubeconfig-path' for contents to write to KACHE."
+  (file-notify-rm-watch (oref kache kubeconfig-watch-id)))
+
+(cl-defmethod kele--cache-start ((kache kele--kache) &key bootstrap)
+  "Start the KACHE.
+
+Start watching the kubeconfig and start timers for each clusters'
+  respective entries in the discovery cache.
+
+BOOTSTRAP is ignored."
+  (oset kache kubeconfig-watch-id
         (file-notify-add-watch
          kele-kubeconfig-path
          '(change)
-         (-partial #'kele--cache-update cache)))
+         (-partial #'kele--kubeconfig-update kache)))
   (when bootstrap
-    (kele--cache-update cache)))
+    (kele--cache-update kache)))
+
+(cl-defmethod kele--wait ((cache kele--kache)
+                          &key
+                          (count 10)
+                          (wait 1)
+                          (timeout 100)
+                          (msg "Waiting for kubeconfig update to finish..."))
+  "Wait for CACHE to finish updating.
+
+COUNT, WAIT, and TIMEOUT are as defined in `kele--retry'.
+
+MSG is the progress reporting message to display."
+  (when (oref cache update-in-progress)
+    (kele--with-progress msg
+      (kele--retry (lambda () (not (oref cache update-in-progress)))
+                   :count count :wait wait :timeout timeout))))
+
+(defvar kele--global-kache (kele--kache))
+(defvar kele--global-discovery-cache (kele--discovery-cache))
 
 (defvar kele--context-proxy-ledger nil
   "An alist mapping contexts to their corresponding proxy processes.
@@ -479,15 +516,15 @@ configuration, e.g. via `kubectl config'.
 If WAIT is non-nil, does not wait for any current update process
 to complete.  Returned value may not be up to date."
   (when wait
-    (kele--wait kele--global-kubeconfig-cache))
-  (alist-get 'current-context (oref kele--global-kubeconfig-cache contents)))
+    (kele--wait kele--global-kache))
+  (alist-get 'current-context (oref kele--global-kache kubeconfig-contents)))
 
 (defun kele--default-namespace-for-context (context)
   "Get the defualt namespace for CONTEXT."
   (-if-let* (((&alist 'context (&alist 'namespace namespace))
               (-first (lambda (elem)
                         (string= (alist-get 'name elem) context))
-                      (alist-get 'contexts (oref kele--global-kubeconfig-cache contents)))))
+                      (alist-get 'contexts (oref kele--global-kache kubeconfig-contents)))))
       namespace))
 
 (cl-defun kele-current-namespace (&key (wait t))
@@ -515,18 +552,18 @@ to complete.  Returned value may not be up to date."
   "Get the names of all known contexts."
   (-map
    (lambda (elem) (alist-get 'name elem))
-   (alist-get 'contexts (oref kele--global-kubeconfig-cache contents))))
+   (alist-get 'contexts (oref kele--global-kache kubeconfig-contents))))
 
 (defun kele--context-cluster (context-name)
   "Get the cluster metadata for the context named CONTEXT-NAME."
   (-first (lambda (elem) (string= (alist-get 'name elem)
                                   (kele--context-cluster-name context-name)))
-          (alist-get 'clusters (oref kele--global-kubeconfig-cache contents))))
+          (alist-get 'clusters (oref kele--global-kache kubeconfig-contents))))
 
 (defun kele--context-cluster-name (context-name)
   "Get the name of the cluster of the context named CONTEXT-NAME."
   (if-let ((context (-first (lambda (elem) (string= (alist-get 'name elem) context-name))
-                            (alist-get 'contexts (oref kele--global-kubeconfig-cache contents)))))
+                            (alist-get 'contexts (oref kele--global-kache kubeconfig-contents)))))
       (alist-get 'cluster (alist-get 'context context))
     (error "Could not find context of name %s" context-name)))
 
@@ -534,11 +571,11 @@ to complete.  Returned value may not be up to date."
   "Return annotation text for the context named CONTEXT-NAME."
   (let* ((context (-first (lambda (elem)
                             (string= (alist-get 'name elem) context-name))
-                          (alist-get 'contexts (oref kele--global-kubeconfig-cache contents))))
+                          (alist-get 'contexts (oref kele--global-kache kubeconfig-contents))))
          (cluster-name (or (alist-get 'cluster (alist-get 'context context)) ""))
          (cluster (-first (lambda (elem)
                             (string= (alist-get 'name elem) cluster-name))
-                          (-concat (alist-get 'clusters (oref kele--global-kubeconfig-cache contents)) '())))
+                          (-concat (alist-get 'clusters (oref kele--global-kache kubeconfig-contents)) '())))
          (server (or (alist-get 'server (alist-get 'cluster cluster)) ""))
          (proxy-active-p (assoc (intern context-name) kele--context-proxy-ledger))
          (proxy-status (if proxy-active-p
@@ -1141,7 +1178,7 @@ This is idempotent."
   (unless kele--enabled
     (setq kele--enabled t)
     ;; FIXME: Update the watcher when `kele-kubeconfig-path' changes.
-    (kele--cache-start kele--global-kubeconfig-cache :bootstrap t)
+    (kele--cache-start kele--global-kache :bootstrap t)
     ;; FIXME: Update the watcher when `kele-cache-dir' changes.
     (kele--cache-start kele--global-discovery-cache :bootstrap t)
 
@@ -1156,7 +1193,7 @@ This is idempotent."
 This is idempotent."
   (unless (not kele--enabled)
     (setq kele--enabled nil)
-    (kele--cache-stop kele--global-kubeconfig-cache)
+    (kele--cache-stop kele--global-kache)
     (kele--cache-stop kele--global-discovery-cache)
     (kele--teardown-embark-maybe)
     (if (featurep 'awesome-tray)
@@ -1622,6 +1659,12 @@ The `scope' is the current context name."
    ("P" kele-proxy-toggle :description "Start/stop proxy server for...")]
   (interactive)
   (transient-setup 'kele-proxy nil nil :scope (kele-current-context-name)))
+
+(defcustom kele-discovery-refresh-interval
+  600
+  "Default interval for polling clusters' discovery cache."
+  :type 'integer
+  :group 'kele)
 
 (provide 'kele)
 

--- a/tests/integration/test-integration.el
+++ b/tests/integration/test-integration.el
@@ -15,7 +15,7 @@
     (it "switches context properly"
       (kele-context-switch "kind-kele-test-cluster0")
       (kele-namespace-switch-for-context "kind-kele-test-cluster0" "kube-public")
-      (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+      (async-wait (kele--cache-update kele--global-kache))
       (expect (kele-current-namespace) :to-equal "kube-public"))))
 
 (describe "kele--fetch-resource-names"
@@ -50,7 +50,7 @@
 
   (it "retrieves the resource as an alist"
     (async-wait (kele--cache-update kele--global-discovery-cache))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
     (setq retval (kele--get-resource "deployments" "coredns"
                                                 :group "apps"
                                                 :version "v1"
@@ -62,7 +62,7 @@
 
   (it "returns an error if the resource is nonsense or does not exist"
     (async-wait (kele--cache-update kele--global-discovery-cache))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
     (expect (kele--get-resource "salaries" "mine"
                                            :group "hello"
                                            :version "v1"
@@ -78,7 +78,7 @@
 (describe "kele-get"
   (it "fetches the resource"
     (async-wait (kele--cache-update kele--global-discovery-cache))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
     (with-simulated-input
         "deployments RET kube-system RET coredns RET"
       (call-interactively #'kele-get))
@@ -89,7 +89,7 @@
 (describe "kele-list"
   (before-all
     (async-wait (kele--cache-update kele--global-discovery-cache))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache)))
+    (async-wait (kele--cache-update kele--global-kache)))
   (it "lists all resources of the given type"
     (kele-list "apps/v1" "deployments" "kind-kele-test-cluster0" "kube-system")
     (expect (-map #'buffer-name (buffer-list))

--- a/tests/integration/test-ui.el
+++ b/tests/integration/test-ui.el
@@ -14,7 +14,7 @@
 
     (before-all
       (async-wait (kele--cache-update kele--global-discovery-cache))
-      (async-wait (kele--cache-update kele--global-kubeconfig-cache)))
+      (async-wait (kele--cache-update kele--global-kache)))
 
     (describe "prefix buffer contents"
       (before-all

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -65,19 +65,19 @@
 (describe "kele-current-context-name"
   (it "returns the correct current-context value"
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
     (expect (kele-current-context-name) :to-equal "development")))
 
 (describe "kele--context-annotate"
   (it "returns the proper annotation text"
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
     (expect (kele--context-annotate "development") :to-equal " (development-cluster, https://123.456.789.0:9999, Proxy OFF)")))
 
 (describe "kele-context-names"
   (it "returns the correct cluster names"
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
 
     (expect (kele-context-names) :to-equal '("development" "no-namespace"))))
 
@@ -93,7 +93,7 @@
 (describe "kele-current-namespace"
   (before-each
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache)))
+    (async-wait (kele--cache-update kele--global-kache)))
   (it "returns the default namespace for the current cluster"
     (spy-on 'kele-current-context-name :and-return-value "development")
     (expect (kele-current-namespace) :to-equal "development-namespace"))
@@ -104,14 +104,14 @@
 (describe "kele--get-host-for-context"
   (it "returns the correct value"
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
     (expect (kele--get-host-for-context "development") :to-equal "123.456.789.0:9999")
     (expect (kele--get-host-for-context "no-namespace") :to-equal "111.111.111.111")))
 
 (describe "kele--context-cluster-name"
   (it "returns the correct cluster"
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache))
+    (async-wait (kele--cache-update kele--global-kache))
     (expect (kele--context-cluster-name "development") :to-equal "development-cluster")))
 
 (describe "kele--retry"
@@ -305,11 +305,11 @@
                 "services/status"
                 "ambiguousthings")))))
 
-(describe "kele--kubeconfig-cache"
+(describe "kele--kache"
   :var (cache)
   (describe "kele--cache-start"
     (before-each
-      (setq cache (kele--kubeconfig-cache))
+      (setq cache (kele--kache))
       (spy-on 'file-notify-add-watch :and-return-value :fnotify-id)
       (spy-on 'kele--cache-update)
       (kele--cache-start cache :bootstrap t))
@@ -317,7 +317,7 @@
       (it "performs an initial update"
         (expect 'kele--cache-update :to-have-been-called-with cache)))
     (it "sets the filewatch field"
-      (expect (oref cache filewatch-id) :to-equal :fnotify-id))))
+      (expect (oref cache kubeconfig-watch-id) :to-equal :fnotify-id))))
 
 (describe "kele--discovery-cache"
   :var (cache)
@@ -428,7 +428,7 @@ metadata:
     (setq kele-cache-dir (f-expand "./tests/testdata/cache"))
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
     (async-wait (kele--cache-update kele--global-discovery-cache))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache)))
+    (async-wait (kele--cache-update kele--global-kache)))
 
   (describe "when resource is not namespaced"
     (it "errors when namespace is provided anyway"
@@ -564,7 +564,7 @@ metadata:
 (describe "kele--get-namespace-arg"
   (before-all
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
-    (async-wait (kele--cache-update kele--global-kubeconfig-cache)))
+    (async-wait (kele--cache-update kele--global-kache)))
   (describe "when called in a Transient suffix"
     (before-each
       (setq transient-current-command t)


### PR DESCRIPTION
Contributes to #89.

This PR folds the existing kubeconfig cache class into a higher-level cache to encompass both kubeconfig and discovery cache, in accordance w/ and preparation for the design outlined in 08d8ecef7cf5627776f6ca60e2ab205fbee9c0f9.