### PR TITLE
Implement "lazy" proxy manager

### DIFF
--- a/docs/references/changelog.md
+++ b/docs/references/changelog.md
@@ -14,6 +14,8 @@ versioning][semver].
 ### Fixed
 
 - Fixed an issue where Kele can exhaust the number of file descriptors available for Emacs to use.
+- Fixed an issue where command families that require proxy servers, e.g. `kele-resource`, result in false-positive
+  timeout errors when starting up the proxy server.
 
 ### Changed
 

--- a/kele.el
+++ b/kele.el
@@ -1042,7 +1042,8 @@ If CONTEXT is not provided, use the current context."
                    kind)))
     (signal 'user-error '()))
 
-  (-if-let* ((port (->> (or context (kele-current-context-name))
+  (-if-let* ((ctx (or context (kele-current-context-name)))
+             (port (->> ctx
                         (proxy-start kele--global-proxy-manager)
                         (kele--proxy-record-port)))
              (url (format "http://localhost:%s/%s/%s"
@@ -1053,7 +1054,7 @@ If CONTEXT is not provided, use the current context."
                           kind))
 
              ;; Block on proxy readiness
-             (proxy (proxy-get kele--global-proxy-manager))
+             (proxy (proxy-get kele--global-proxy-manager ctx))
 
              (data (kele--retry (lambda () (plz 'get url :as #'json-read))))
              (filtered-items (->> (append  (alist-get 'items data) '())

--- a/kele.el
+++ b/kele.el
@@ -755,17 +755,15 @@ Returns the proxy process."
     (proxy-start kele--global-proxy-manager context :port port :ephemeral ephemeral)
     (proxy-get kele--global-proxy-manager context :wait t)))
 
-(defun kele--proxy-enabled-p (context)
-  "Return non-nil if proxy server process active for CONTEXT."
-  (proxy-active-p kele--global-proxy-manager context))
-
 (defun kele-proxy-toggle (context)
   "Start or stop proxy server process for CONTEXT."
   (interactive (list (completing-read
                       "Start/stop proxy for context: "
                       #'kele--contexts-complete)))
   (funcall
-   (if (kele--proxy-enabled-p context) #'kele-proxy-stop #'kele-proxy-start)
+   (if (proxy-active-p kele--global-proxy-manager context)
+       #'kele-proxy-stop
+     #'kele-proxy-start)
    context))
 
 (cl-defun kele--ensure-proxy (context)
@@ -1653,7 +1651,9 @@ instead of \"pod.\""
   :description
   (lambda ()
     (format "%s proxy server for %s"
-            (if (kele--proxy-enabled-p (oref transient--prefix scope))
+            (if (proxy-active-p
+                 kele--global-proxy-manager
+                 (oref transient--prefix scope))
                 "Disable"
               "Enable")
             (propertize (oref transient--prefix scope) 'face

--- a/kele.el
+++ b/kele.el
@@ -479,10 +479,10 @@ existing process *regardless of the value of PORT*."
                       (run-with-timer kele-proxy-ttl nil (-partial #'proxy-stop
                                                                    manager
                                                                    context)))))
-      (add-to-list (oref manager procs) `(,context . ,proc))
-      (add-to-list (oref manager ports) `(,context . ,selected-port))
+      (oset manager procs (cons `(,context . ,proc) (oref manager procs)))
+      (oset manager ports (cons `(,context . ,selected-port) (oref manager ports)))
       (when cleanup
-        (add-to-list (oref manager timers) `(,context . ,cleanup)))
+        (oset manager timers (cons `(,context . ,cleanup) (oref manager timers))))
       proc)))
 
 (cl-defmethod proxy-get ((manager kele--proxy-manager)

--- a/kele.el
+++ b/kele.el
@@ -1045,6 +1045,7 @@ If CONTEXT is not provided, use the current context."
   (-if-let* ((port (->> (or context (kele-current-context-name))
                         (proxy-start kele--global-proxy-manager)
                         (kele--proxy-record-port)))
+             (_ (proxy-get kele--global-proxy-manager))
              (url (format "http://localhost:%s/%s/%s"
                           port
                           (if group

--- a/kele.el
+++ b/kele.el
@@ -1042,9 +1042,9 @@ If CONTEXT is not provided, use the current context."
                    kind)))
     (signal 'user-error '()))
 
-  (-if-let* ((port (kele--proxy-record-port
-                    (proxy-start kele--global-proxy-manager
-                                 (or context (kele-current-context-name)))))
+  (-if-let* ((ctx (or context (kele-current-context-name)))
+             (port (kele--proxy-record-port
+                    (proxy-start kele--global-proxy-manager ctx)))
              (url (format "http://localhost:%s/%s/%s"
                           port
                           (if group

--- a/kele.el
+++ b/kele.el
@@ -1042,7 +1042,7 @@ If CONTEXT is not provided, use the current context."
                    kind)))
     (signal 'user-error '()))
 
-  (let* ((ctx (or (kele-current-context-name)))
+  (let* ((ctx (or context (kele-current-context-name)))
          (port (kele--proxy-record-port
                 (proxy-start kele--global-proxy-manager ctx)))
          (url (format "http://localhost:%s/%s/%s"

--- a/kele.el
+++ b/kele.el
@@ -753,14 +753,16 @@ after a certain amount of time.
 
 If PORT is nil, a random port will be chosen.
 
-Returns the proxy process."
+Returns an alist with keys `proc', `timer', and `port'."
   (interactive (list (completing-read "Start proxy for context: " #'kele--contexts-complete)
                      :port nil
                      :ephemeral t))
   ;; TODO: Throw error if proxy already active for context
   (kele--with-progress (format "Starting proxy server process for `%s'..." context)
     (proxy-start kele--global-proxy-manager context :port port :ephemeral ephemeral)
-    (proxy-get kele--global-proxy-manager context :wait t)))
+    (list (cons 'proc (proxy-get kele--global-proxy-manager context :wait t))
+          (cons 'timer (cdr (assoc context (oref kele--global-proxy-manager timers))))
+          (cons 'port port))))
 
 (defun kele-proxy-toggle (context)
   "Start or stop proxy server process for CONTEXT."

--- a/kele.el
+++ b/kele.el
@@ -1042,10 +1042,9 @@ If CONTEXT is not provided, use the current context."
                    kind)))
     (signal 'user-error '()))
 
-  (-if-let* ((ctx (or context (kele-current-context-name)))
-             (port (->> ctx
-                        (proxy-start kele--global-proxy-manager)
-                        (kele--proxy-record-port)))
+  (-if-let* ((port (kele--proxy-record-port
+                    (proxy-start kele--global-proxy-manager
+                                 (or context (kele-current-context-name)))))
              (url (format "http://localhost:%s/%s/%s"
                           port
                           (if group

--- a/kele.el
+++ b/kele.el
@@ -439,15 +439,21 @@ contents."
   ((procs
     :documentation
     "Alist of context names to proxy processes."
+    :initarg :procs
+    :type list
     :initform nil)
    (timers
     :documentation
     "Alist of context names to timer objects that terminate and clean up the
   proxy processes."
+    :initarg :timers
+    :type list
     :initform nil)
    (ports
     :documentation
     "Alist of context names to the corresponding proxy's port."
+    :initarg :ports
+    :type list
     :initform nil))
   "Manage proxy server processes.")
 
@@ -525,7 +531,8 @@ returns nil."
 (cl-defmethod proxy-active-p ((manager kele--proxy-manager)
                               context)
   "Return non-nil if a proxy serve is active for CONTEXT in MANAGER."
-  (assoc context (oref manager procs)))
+  (when-let (res (assoc context (oref manager procs)))
+    (cdr res)))
 
 (defvar kele--global-proxy-manager (kele--proxy-manager))
 

--- a/kele.el
+++ b/kele.el
@@ -760,7 +760,7 @@ Returns an alist with keys `proc', `timer', and `port'."
   ;; TODO: Throw error if proxy already active for context
   (kele--with-progress (format "Starting proxy server process for `%s'..." context)
     (proxy-start kele--global-proxy-manager context :port port :ephemeral ephemeral)
-    (list (cons 'proc (proxy-get kele--global-proxy-manager context :wait t))
+    (list (cons 'proc (proxy-get kele--global-proxy-manager context :wait nil))
           (cons 'timer (cdr (assoc context (oref kele--global-proxy-manager timers))))
           (cons 'port port))))
 

--- a/kele.el
+++ b/kele.el
@@ -674,8 +674,11 @@ Returns the proxy process."
    context))
 
 (cl-defun kele--ensure-proxy (context)
-  "Return a proxy process for CONTEXT, creating one if needed."
-  (kele-proxy-start context))
+  "Return a proxy process for CONTEXT, creating one if needed.
+
+Returns the port of the proxy process."
+  (kele-proxy-start context)
+  (cdr (assoc context (oref kele--global-proxy-manager ports))))
 
 (defvar kele--context-resources nil
   "An alist mapping contexts to their cached resources.
@@ -791,7 +794,7 @@ throws an error."
             (url-all (concat url-gv "/"
                              (if namespace (format "namespaces/%s/" namespace) "")
                              url-res))
-            ((&alist 'port port) (kele--ensure-proxy context))
+            (port (kele--ensure-proxy context))
             (url (format "http://localhost:%s/%s" port url-all)))
       (condition-case err
           (kele--resource-container-create
@@ -947,8 +950,8 @@ If CONTEXT is not provided, use the current context."
                    kind)))
     (signal 'user-error '()))
 
-  (-if-let* (((&alist 'port port) (kele--ensure-proxy
-                                   (or context (kele-current-context-name))))
+  (-if-let* ((port (kele--ensure-proxy
+                    (or context (kele-current-context-name))))
              (url (format "http://localhost:%s/%s/%s"
                           port
                           (if group

--- a/kele.el
+++ b/kele.el
@@ -521,11 +521,11 @@ If no process active for CONTEXT, this function is a no-op and
 returns nil."
   (-when-let ((&alist context proc) (oref manager procs))
     (kele--kill-process-quietly proc)
-    (assoc-delete-all context (oref manager procs))
-    (assoc-delete-all context (oref manager ports))
+    (oset manager procs (assoc-delete-all context (oref manager procs)))
+    (oset manager ports (assoc-delete-all context (oref manager ports)))
     (-when-let ((&alist context timer) (oref manager timers))
       (cancel-timer timer)
-      (assoc-delete-all context (oref manager timers))))
+      (oset manager timers (assoc-delete-all context (oref manager timers)))))
   (message (format "[kele] Stopped proxy for context `%s'" context)))
 
 (cl-defmethod proxy-active-p ((manager kele--proxy-manager)

--- a/kele.el
+++ b/kele.el
@@ -435,6 +435,101 @@ contents."
   (when bootstrap
     (kele--cache-update cache)))
 
+(defclass kele--proxy-manager ()
+  ((procs
+    :documentation
+    "Alist of context names to proxy processes."
+    :initform nil)
+   (timers
+    :documentation
+    "Alist of context names to timer objects that terminate and clean up the
+  proxy processes."
+    :initform nil)
+   (ports
+    :documentation
+    "Alist of context names to the corresponding proxy's port."
+    :initform nil))
+  "Manage proxy server processes.")
+
+(cl-defmethod proxy-start ((manager kele--proxy-manager)
+                           context
+                           &key port (ephemeral t))
+  "Start a proxy process within MANAGER for CONTEXT at PORT.
+
+If EPHEMERAL is non-nil, the proxy process will be cleaned up
+after a certain amount of time.
+
+If PORT is nil, a random port will be chosen.
+
+Returns the proxy process.
+
+If CONTEXT already has a proxy process active, this function returns the
+existing process *regardless of the value of PORT*."
+  (-if-let ((&alist context proc) (oref manager procs))
+      proc
+    (let* ((selected-port (or port (kele--random-port)))
+           (proc (kele--proxy-process context :port selected-port :wait nil))
+           (cleanup (when ephemeral
+                      (run-with-timer kele-proxy-ttl nil (-partial #'proxy-stop
+                                                                   manager
+                                                                   context)))))
+      (add-to-list (oref manager procs) `(,context . ,proc))
+      (add-to-list (oref manager ports) `(,context . ,selected-port))
+      (when cleanup
+        (add-to-list (oref manager timers) `(,context . ,cleanup)))
+      proc)))
+
+(cl-defmethod proxy-get ((manager kele--proxy-manager)
+                         context
+                         &key (wait t))
+  "Retrieve the proxy process from MANAGER for CONTEXT.
+
+If WAIT is non-nil, polls the liveliness and health endpoints for
+  the proxy server until they respond successfully.
+
+This function assumes that the proxy process has already been started.  It will
+  not start a proxy server if one has not already been started."
+  (-when-let* (((&alist context proc) (oref manager procs))
+               ((&alist context port) (oref manager ports))
+               (s-port (number-to-string port))
+               (ready-addr (format "http://localhost:%s/readyz" s-port))
+               (live-addr (format "http://localhost:%s/livez" s-port)))
+    (when wait
+      (kele--retry (lambda ()
+                     ;; /readyz and /livez can sometimes return nil, maybe when
+                     ;; the proxy is just starting up. Add retries for these.
+                     (when-let* ((resp-ready (plz 'get ready-addr :as 'response))
+                                 (resp-live (plz 'get live-addr :as 'response))
+                                 (status-ready (plz-response-status resp-ready))
+                                 (status-live (plz-response-status resp-live)))
+                       (and (= 200 status-ready) (= 200 status-live))))
+                   :wait 2
+                   :count 10))
+    proc))
+
+(cl-defmethod proxy-stop ((manager kele--proxy-manager)
+                          context)
+  "Stop the proxy process in MANAGER for CONTEXT.
+
+If no process active for CONTEXT, this function is a no-op and
+returns nil."
+  (-when-let ((&alist context proc) (oref manager procs))
+    (kele--kill-process-quietly proc)
+    (assoc-delete-all context (oref manager procs))
+    (assoc-delete-all context (oref manager ports))
+    (-when-let ((&alist context timer) (oref manager timers))
+      (cancel-timer timer)
+      (assoc-delete-all context (oref manager timers))))
+  (message (format "[kele] Stopped proxy for context `%s'" context)))
+
+(cl-defmethod proxy-active-p ((manager kele--proxy-manager)
+                              context)
+  "Return non-nil if a proxy serve is active for CONTEXT in MANAGER."
+  (assoc context (oref manager procs)))
+
+(defvar kele--global-proxy-manager (kele--proxy-manager))
+
+
 (cl-defun kele--get-resource-types-for-context (context-name &key verb)
   "Retrieve the names of all resource types for CONTEXT-NAME.
 
@@ -1541,6 +1636,7 @@ instead of \"pod.\""
                             kind
                             :context context)))
                  (list gvs kind)))
+  ;; TODO: `proxy-start' for the selected context
   (transient-setup 'kele-resource nil nil :scope `((group-versions . ,group-versions)
                                                    (kind . ,kind)
                                                    (context . ,(kele-current-context-name)))))
@@ -1591,100 +1687,6 @@ The `scope' is the current context name."
    ("P" kele-proxy-toggle :description "Start/stop proxy server for...")]
   (interactive)
   (transient-setup 'kele-proxy nil nil :scope (kele-current-context-name)))
-
-(defclass kele--proxy-manager ()
-  ((procs
-    :documentation
-    "Alist of context names to proxy processes."
-    :initform nil)
-   (timers
-    :documentation
-    "Alist of context names to timer objects that terminate and clean up the
-  proxy processes."
-    :initform nil)
-   (ports
-    :documentation
-    "Alist of context names to the corresponding proxy's port."
-    :initform nil))
-  "Manage proxy server processes.")
-
-(cl-defmethod proxy-start ((manager kele--proxy-manager)
-                           context
-                           &key port (ephemeral t))
-  "Start a proxy process within MANAGER for CONTEXT at PORT.
-
-If EPHEMERAL is non-nil, the proxy process will be cleaned up
-after a certain amount of time.
-
-If PORT is nil, a random port will be chosen.
-
-Returns the proxy process.
-
-If CONTEXT already has a proxy process active, this function returns the
-existing process *regardless of the value of PORT*."
-  (-if-let ((&alist context proc) (oref manager procs))
-      proc
-    (let* ((selected-port (or port (kele--random-port)))
-           (proc (kele--proxy-process context :port selected-port :wait nil))
-           (cleanup (when ephemeral
-                      (run-with-timer kele-proxy-ttl nil (-partial #'proxy-stop
-                                                                   manager
-                                                                   context)))))
-      (add-to-list (oref manager procs) `(,context . ,proc))
-      (add-to-list (oref manager ports) `(,context . ,selected-port))
-      (when cleanup
-        (add-to-list (oref manager timers) `(,context . ,cleanup)))
-      proc)))
-
-(cl-defmethod proxy-get ((manager kele--proxy-manager)
-                         context
-                         &key (wait t))
-  "Retrieve the proxy process from MANAGER for CONTEXT.
-
-If WAIT is non-nil, polls the liveliness and health endpoints for
-  the proxy server until they respond successfully.
-
-This function assumes that the proxy process has already been started.  It will
-  not start a proxy server if one has not already been started."
-  (-when-let* (((&alist context proc) (oref manager procs))
-               ((&alist context port) (oref manager ports))
-               (s-port (number-to-string port))
-               (ready-addr (format "http://localhost:%s/readyz" s-port))
-               (live-addr (format "http://localhost:%s/livez" s-port)))
-    (when wait
-      (kele--retry (lambda ()
-                     ;; /readyz and /livez can sometimes return nil, maybe when
-                     ;; the proxy is just starting up. Add retries for these.
-                     (when-let* ((resp-ready (plz 'get ready-addr :as 'response))
-                                 (resp-live (plz 'get live-addr :as 'response))
-                                 (status-ready (plz-response-status resp-ready))
-                                 (status-live (plz-response-status resp-live)))
-                       (and (= 200 status-ready) (= 200 status-live))))
-                   :wait 2
-                   :count 10))
-    proc))
-
-(cl-defmethod proxy-stop ((manager kele--proxy-manager)
-                          context)
-  "Stop the proxy process in MANAGER for CONTEXT.
-
-If no process active for CONTEXT, this function is a no-op and
-returns nil."
-  (-when-let ((&alist context proc) (oref manager procs))
-    (kele--kill-process-quietly proc)
-    (assoc-delete-all context (oref manager procs))
-    (assoc-delete-all context (oref manager ports))
-    (-when-let ((&alist context timer) (oref manager timers))
-      (cancel-timer timer)
-      (assoc-delete-all context (oref manager timers))))
-  (message (format "[kele] Stopped proxy for context `%s'" context)))
-
-(cl-defmethod proxy-active-p ((manager kele--proxy-manager)
-                              context)
-  "Return non-nil if a proxy serve is active for CONTEXT in MANAGER."
-  (assoc context (oref manager procs)))
-
-(defvar kele--global-proxy-manager (kele--proxy-manager))
 
 (provide 'kele)
 

--- a/kele.el
+++ b/kele.el
@@ -453,11 +453,13 @@ TIMER, if non-nil, is the cleanup timer."
   (format "http://localhost:%s" (kele--proxy-record-port proxy)))
 
 (cl-defmethod ready-p ((proxy kele--proxy-record))
-  "Return non-nil if the PROXY is ready for requests."
+  "Return non-nil if the PROXY is ready for requests.
+
+Returns nil on any curl error."
   (let ((ready-addr (format "%s/readyz" (kele--url proxy)))
         (live-addr (format "%s/livez" (kele--url proxy))))
-    (when-let* ((resp-ready (plz 'get ready-addr :as 'response))
-                (resp-live (plz 'get live-addr :as 'response))
+    (when-let* ((resp-ready (plz 'get ready-addr :as 'response :else 'ignore))
+                (resp-live (plz 'get live-addr :as 'response :else 'ignore))
                 (status-ready (plz-response-status resp-ready))
                 (status-live (plz-response-status resp-live)))
       (and (= 200 status-ready) (= 200 status-live)))))

--- a/kele.el
+++ b/kele.el
@@ -1045,13 +1045,16 @@ If CONTEXT is not provided, use the current context."
   (-if-let* ((port (->> (or context (kele-current-context-name))
                         (proxy-start kele--global-proxy-manager)
                         (kele--proxy-record-port)))
-             (_ (proxy-get kele--global-proxy-manager))
              (url (format "http://localhost:%s/%s/%s"
                           port
                           (if group
                               (format "apis/%s/%s" group version)
                             (format "api/%s" version))
                           kind))
+
+             ;; Block on proxy readiness
+             (proxy (proxy-get kele--global-proxy-manager))
+
              (data (kele--retry (lambda () (plz 'get url :as #'json-read))))
              (filtered-items (->> (append  (alist-get 'items data) '())
                                   (-filter (lambda (item)

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -143,16 +143,16 @@
               '((proc . fake-proc)
                 (timer . nil)
                 (port . 9999)))
-      (expect (assoc "foobar" (oref kele--global-proxy-manager procs) :to-equal '("foobar" . 'fake-proc)))
-      (expect (assoc "foobar" (oref kele--global-proxy-manager timers) :to-equal nil))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager procs)) :to-equal '("foobar" . fake-proc))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager timers)) :to-equal nil)
       (expect 'cancel-timer :not :to-have-been-called)))
 
   (describe "when ephemeral is non-nil"
     (it "adds an entry with a timer"
       (kele-proxy-start "foobar" :port 9999)
 
-      (expect (assoc "foobar" (oref kele--global-proxy-manager procs) :to-equal '("foobar" . 'fake-proc)))
-      (expect (assoc "foobar" (oref kele--global-proxy-manager timers) :to-equal '("foobar" . 'fake-timer))))))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager procs)) :to-equal '("foobar" . fake-proc))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager timers)) :to-equal '("foobar" . fake-timer)))))
 
 (describe "kele--ensure-proxy"
   (before-each

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -131,7 +131,9 @@
 (describe "kele-proxy-start"
   (before-each
     (spy-on 'kele--proxy-process :and-return-value 'fake-proc)
+    (spy-on 'proxy-get :and-return-value 'fake-proc)
     (spy-on 'run-with-timer :and-return-value 'fake-timer)
+    (spy-on 'cancel-timer)
     (setq kele--global-proxy-manager (kele--proxy-manager)))
 
   (describe "when ephemeral is nil"
@@ -142,7 +144,8 @@
                 (timer . nil)
                 (port . 9999)))
       (expect (assoc "foobar" (oref kele--global-proxy-manager procs) :to-equal '("foobar" . 'fake-proc)))
-      (expect (assoc "foobar" (oref kele--global-proxy-manager timers) :to-equal nil))))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager timers) :to-equal nil))
+      (expect 'cancel-timer :not :to-have-been-called)))
 
   (describe "when ephemeral is non-nil"
     (it "adds an entry with a timer"

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -36,17 +36,21 @@
   (it "returns the retval of the last evaluated sexp"
     (expect (kele--with-progress "foobar" (= 1 1)) :to-equal t)))
 
-(describe "kele--proxy-enabled-p"
-  (before-each
-    (setq kele--context-proxy-ledger '((foo . bar)
-                                       (baz . nil))))
+(describe "kele--proxy-manager"
+  :var (manager)
 
-  (it "evals to non-nil if context present in `kele--context-proxy-ledger'"
-    (expect (kele--proxy-enabled-p "foo") :to-be-truthy))
+  (describe "proxy-active-p"
+    (before-each
+      (setq manager (kele--proxy-manager
+                     :procs '(("context-a" . :fake-proc)
+                              ("context-b" . nil)))))
 
-  (it "evals to nil if context not present in `kele--context-proxy-ledger'"
-    (expect (kele--proxy-enabled-p "qux") :not :to-be-truthy)
-    (expect (kele--proxy-enabled-p "baz") :not :to-be-truthy)))
+    (it "evals to non-nil if context present"
+      (expect (proxy-active-p manager "context-a") :to-be-truthy))
+
+    (it "evals to nil if context not present"
+      (expect (proxy-active-p manager "other-context") :not :to-be-truthy)
+      (expect (proxy-active-p manager "context-b") :not :to-be-truthy))))
 
 (describe "kele-status-simple"
   (it "renders with context and namespace"

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -132,7 +132,7 @@
   (before-each
     (spy-on 'kele--proxy-process :and-return-value 'fake-proc)
     (spy-on 'run-with-timer :and-return-value 'fake-timer)
-    (setq kele--context-proxy-ledger nil))
+    (setq kele--global-proxy-manager (kele--proxy-manager)))
 
   (describe "when ephemeral is nil"
     (it "adds an entry with no timer"
@@ -141,20 +141,15 @@
               '((proc . fake-proc)
                 (timer . nil)
                 (port . 9999)))
-      (expect (alist-get 'foobar kele--context-proxy-ledger)
-              :to-equal
-              '((proc . fake-proc)
-                (timer . nil)
-                (port . 9999)))))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager procs) :to-equal '("foobar" . 'fake-proc)))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager timers) :to-equal nil))))
 
   (describe "when ephemeral is non-nil"
     (it "adds an entry with a timer"
       (kele-proxy-start "foobar" :port 9999)
-      (expect (alist-get 'foobar kele--context-proxy-ledger)
-              :to-equal
-              '((proc . fake-proc)
-                (timer . fake-timer)
-                (port . 9999))))))
+
+      (expect (assoc "foobar" (oref kele--global-proxy-manager procs) :to-equal '("foobar" . 'fake-proc)))
+      (expect (assoc "foobar" (oref kele--global-proxy-manager timers) :to-equal '("foobar" . 'fake-timer))))))
 
 (describe "kele--ensure-proxy"
   (before-each

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -419,7 +419,7 @@ metadata:
 (describe "kele--get-resource"
   (before-each
     (spy-on 'plz)
-    (spy-on 'kele--ensure-proxy :and-return-value '((port . 9999)))
+    (spy-on 'kele--ensure-proxy :and-return-value 9999)
     (setq kele-cache-dir (f-expand "./tests/testdata/cache"))
     (setq kele-kubeconfig-path (f-expand "./tests/testdata/kubeconfig.yaml"))
     (async-wait (kele--cache-update kele--global-discovery-cache))

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -159,20 +159,15 @@
 (describe "kele--ensure-proxy"
   (before-each
     (spy-on 'kele-proxy-start)
-    (setq kele--context-proxy-ledger nil))
-  (describe "when proxy present"
-    (before-each
-      (add-to-list 'kele--context-proxy-ledger '(foobar . ((proc . fake-proc)
-                                                           (timer . fake-timer)
-                                                           (port . 9999)))))
-    (it "returns the ledger entry"
-      (expect (kele--ensure-proxy "foobar") :to-equal '((proc . fake-proc)
-                                                        (timer . fake-timer)
-                                                        (port . 9999)))))
-  (describe "when proxy not already present"
-    (it "creates the proxy"
-      (kele--ensure-proxy "foobar")
-      (expect 'kele-proxy-start :to-have-been-called-with "foobar"))))
+    (setq kele--global-proxy-manager (kele--proxy-manager
+                                      :ports '(("context-a" . 9999)))))
+
+  (it "calls `kele-proxy-start' unconditionally"
+    (kele--ensure-proxy "context-a")
+    (expect 'kele-proxy-start :to-have-been-called-with "context-a"))
+
+  (it "returns the port"
+    (expect (kele--ensure-proxy "context-a") :to-equal 9999)))
 
 (describe "kele--clear-namespaces-for-context"
   (before-each


### PR DESCRIPTION
Closes #72.
Contributes to #151.

With this change, we decouple startup of a context's proxy server from its "readiness" checks. The readiness check effectively becomes "just-in-time," taking place right when a subroutine actually intends to use the server. This prevents false-positive timeout errors from the proxy server spinning up. This allows top-level commands, e.g. the `kele-resource` prefix, to initialize the proxy server and allow it to "preheat" before a suffix like `kele-get` actually gets around to using it.