### PR TITLE
Update customization.md keybinding example

### DIFF
--- a/docs/how-tos/customization.md
+++ b/docs/how-tos/customization.md
@@ -16,7 +16,7 @@ keybinding **prefix** for all of Kele's keybindings.
 To bind, say, `s-k` as the keybinding prefix:
 
 ```emacs-lisp
-(define-key kele-mode-map (kbd "s-k") 'kele-command-map)
+(define-key kele-mode-map (kbd "s-k") kele-command-map)
 ```
 
 Now you can use, for example, `s-k c` to access [context-related


### PR DESCRIPTION
Hey there, just a small update I was having trouble with when I was trying to get this set up for myself.

The `define-key` example provided to bind `s-k` quotes `kele-command-map` which is not the correct usage. This returns an error: `Wrong type argument: commandp, kele-command-map` It should instead use the bare symbol rather than quoting it as we need to call the keymap itself, not the symbol representing it.