### PR TITLE
fix: handle uppercase letters in cluster URL

### DIFF
--- a/docs/references/changelog.md
+++ b/docs/references/changelog.md
@@ -17,6 +17,12 @@ versioning][semver].
 - `kele-resource` now has a dedicated section for **kind-specific actions** that
   populates based on the resource kind you selected.
 
+### Fixed
+
+- Fixed a bug where kubeconfig cluster entries with uppercase letters in the
+  server address erroneously cause resource kind completion to silently fail and
+  show no kinds present in cluster
+
 ### Changed
 
 - Added dependency `memoize`

--- a/kele.el
+++ b/kele.el
@@ -295,7 +295,7 @@ MSG is the progress reporting message to display."
   (alist-get
    (s-replace ":" "_" (kele--get-host-for-context (or context (kele-current-context-name))))
    (oref cache contents)
-   nil nil #'equal))
+   nil nil (-cut compare-strings <> nil nil <> nil nil t)))
 
 (cl-defmethod kele--get-groupversions-for-type ((cache kele--discovery-cache)
                                                 type
@@ -548,6 +548,7 @@ returns nil."
 
 (defvar kele--global-proxy-manager (kele--proxy-manager))
 
+;; FIXME: Returns nil sometimes...
 (cl-defun kele--get-resource-types-for-context (context-name &key verb)
   "Retrieve the names of all resource types for CONTEXT-NAME.
 


### PR DESCRIPTION
We use `url-generic-parse-url` to extract the host and port out of kubeconfig cluster URLs. This has the unfortunate side effect (maybe due to RFC 3986 compliance?) of downcasing the hostname, which results in lookup failure when then using that host to look up in `kele--global-discovery-cache`.

To fix, we switch to case-insensitive lookup for
`kele--get-resource-lists-for-context`.