### PR TITLE
fix: singularize resource names where appropriate

### DIFF
--- a/docs/references/changelog.md
+++ b/docs/references/changelog.md
@@ -24,6 +24,8 @@ versioning][semver].
 - Fixed a bug where kubeconfig cluster entries with uppercase letters in the
   server address erroneously cause resource kind completion to silently fail and
   show no kinds present in cluster
+- Fixed a bug in `kele-resource` where the improper singular/plural form of the
+  resource name is used, e.g. "Get a single pods" instead of "Get a single pod"
 
 ### Changed
 

--- a/tests/testdata/cache/discovery/123.456.789.0_9999/fake-group/v1/serverresources.json
+++ b/tests/testdata/cache/discovery/123.456.789.0_9999/fake-group/v1/serverresources.json
@@ -4,7 +4,7 @@
             "kind": "AmbiguousThingFoo",
             "name": "ambiguousthings",
             "namespaced": true,
-            "singularName": "",
+            "singularName": "ambiguousthing",
             "verbs": [
                 "get"
             ]

--- a/tests/testdata/cache/discovery/123.456.789.0_9999/fake-other-group/v1/serverresources.json
+++ b/tests/testdata/cache/discovery/123.456.789.0_9999/fake-other-group/v1/serverresources.json
@@ -4,7 +4,7 @@
             "kind": "AmbiguousThingBar",
             "name": "ambiguousthings",
             "namespaced": true,
-            "singularName": "",
+            "singularName": "ambiguousthing",
             "verbs": [
                 "get"
             ]

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -336,6 +336,25 @@
     (it "sets the timer"
       (expect (oref cache timer) :to-equal :timer)))
 
+  (describe "kele--get-singular-for-plural"
+    (before-each
+      (setq kele-cache-dir (f-expand "./tests/testdata/cache"))
+      (async-wait (kele--cache-update kele--global-discovery-cache)))
+
+    (it "fetches singularName"
+      (expect
+       (kele--get-singular-for-plural kele--global-discovery-cache
+      "ambiguousthings")
+       :to-equal
+       "ambiguousthing"))
+
+    (describe "when singularName not present"
+      (it "returns lowercased .metadata.name"
+        (expect (kele--get-singular-for-plural kele--global-discovery-cache
+                                               "componentstatuses")
+                :to-equal
+                "componentstatus"))))
+
   (describe "kele--get-groupversions-for-type"
     (before-each
       (setq kele-cache-dir (f-expand "./tests/testdata/cache"))


### PR DESCRIPTION
Closes #196.

Currently, `kele-resource` uses the plural form of the resource name, e.g. `pods`, everywhere. This was done primarily out of convenience but obviously is grammatically inaccurate in some places, e.g. "get a single pods."

Here we introduce a mechanism for looking up the canonical singular form of any given resource name from the discovery cache and apply it to the `kele-resource` suffix labels.