### PR TITLE
Define group-version-kind struct

### DIFF
--- a/kele.el
+++ b/kele.el
@@ -1153,7 +1153,7 @@ If CONTEXT is not provided, use the current context."
                    kele--global-discovery-cache
                    (kele--gv-string gvk)
                    (oref gvk kind))))
-    (user-error "Attempted to fetch un-namespaced resource `%s' as namespaced" kind))
+    (user-error "Attempted to fetch un-namespaced resource `%s' as namespaced" (oref gvk kind)))
 
   (let* ((ctx (or context (kele-current-context-name)))
          (port (kele--proxy-record-port

--- a/kele.el
+++ b/kele.el
@@ -1869,8 +1869,7 @@ to query for."
            (cands (kele--fetch-resource-names gvk :namespace ns :context (kele--get-context-arg)))
            (name (completing-read "Name: " (-cut kele--resources-complete <> <> <> :cands cands))))
      (list (kele--get-context-arg) ns gvk name)))
-  (-let (((group version) (kele--groupversion-split group-version)))
-    (kele--render-object (kele--get-resource gvk name :namespace namespace :context context))))
+  (kele--render-object (kele--get-resource gvk name :namespace namespace :context context)))
 
 (transient-define-suffix kele-deployment-restart (context namespace deployment-name)
   "Restart DEPLOYMENT-NAME.

--- a/kele.el
+++ b/kele.el
@@ -1844,10 +1844,7 @@ to query for."
   :description
   (lambda ()
     (let-alist (oref transient--prefix scope)
-      (if (kele--can-i
-           :verb 'get
-           :resource .kind
-           :context .context)
+      (if (kele--can-i :verb 'get :resource .kind :context .context)
           (format "Get a single %s"
                   (propertize
                    (kele--get-singular-for-plural kele--global-discovery-cache .kind :context .context)

--- a/kele.el
+++ b/kele.el
@@ -1012,7 +1012,7 @@ throws an error."
                                (car group-versions)
                                (oref gvk kind)
                                :context context)))
-      (user-error "Namespace `%s' specified for un-namespaced resource `%s'; remove namespace and try again" namespace kind))
+      (user-error "Namespace `%s' specified for un-namespaced resource `%s'; remove namespace and try again" namespace (oref gvk kind)))
 
     (-let* ((gv (car group-versions))
             (namespace (and (kele--resource-namespaced-p

--- a/kele.el
+++ b/kele.el
@@ -1172,7 +1172,7 @@ If CONTEXT is not provided, use the current context."
           (setf (cdr (assoc 'items data)) filtered-items)
           data)
 
-      (signal 'error (format "Failed to fetch %s/%s/%s" group version kind)))))
+      (signal 'error (format "Failed to fetch %s/%s/%s" (oref gvk group) (oref gvk version) (oref gvk kind))))))
 
 (cl-defun kele--fetch-resource-names (gvk &key namespace context)
   "Fetch names of resources belonging to GVK.

--- a/kele.el
+++ b/kele.el
@@ -1125,17 +1125,6 @@ show the requested Kubernetes object manifest.
 
 (add-hook 'kele-get-mode-hook #'kele--get-insert-header t)
 
-(defun kele--groupversion-string (group version)
-  "Concatenate GROUP and VERSION into single group-version string."
-  (if group (concat group "/" version) version))
-
-(defun kele--gvk-string (group version kind)
-  "Construct GVK string from GROUP, VERSION, and KIND."
-  (let ((vk (format "%s.%s" version kind)))
-    (if group
-        (concat group "/" vk)
-      vk)))
-
 (defun kele--groupversion-split (group-version)
   "Split a single GROUP-VERSION string.
 

--- a/tests/integration/test-integration.el
+++ b/tests/integration/test-integration.el
@@ -23,7 +23,6 @@
     (async-wait (kele--cache-update kele--global-discovery-cache)))
   (it "errors if namespace filtering requested for non-namespaced resource"
     (expect (kele--fetch-resource-names (kele--gvk-create
-                                         :group nil
                                          :version "v1"
                                          :kind "namespaces")
                                         :context "kind-kele-test-cluster0"
@@ -31,7 +30,6 @@
             :to-throw 'user-error))
   (it "fetches core API names"
     (expect (kele--fetch-resource-names (kele--gvk-create
-                                         :group nil
                                          :version "v1"
                                          :kind "namespaces")
                                         :context "kind-kele-test-cluster0")

--- a/tests/integration/test-integration.el
+++ b/tests/integration/test-integration.el
@@ -22,12 +22,19 @@
   (before-each
     (async-wait (kele--cache-update kele--global-discovery-cache)))
   (it "errors if namespace filtering requested for non-namespaced resource"
-    (expect (kele--fetch-resource-names nil "v1" "namespaces"
+    (expect (kele--fetch-resource-names (kele--gvk-create
+                                         :group nil
+                                         :version "v1"
+                                         :kind "namespaces")
                                         :context "kind-kele-test-cluster0"
                                         :namespace "kube-system")
             :to-throw 'user-error))
   (it "fetches core API names"
-    (expect (kele--fetch-resource-names nil "v1" "namespaces" :context "kind-kele-test-cluster0")
+    (expect (kele--fetch-resource-names (kele--gvk-create
+                                         :group nil
+                                         :version "v1"
+                                         :kind "namespaces")
+                                        :context "kind-kele-test-cluster0")
             :to-have-same-items-as
             '("default"
               "kube-node-lease"
@@ -35,11 +42,18 @@
               "kube-system"
               "local-path-storage")))
   (it "fetches group API names"
-    (expect (kele--fetch-resource-names "apps" "v1" "deployments" :context "kind-kele-test-cluster0")
+    (expect (kele--fetch-resource-names (kele--gvk-create
+                                        :group "apps"
+                                        :version "v1"
+                                        :kind "deployments")
+                                        :context "kind-kele-test-cluster0")
             :to-have-same-items-as
             '("coredns" "local-path-provisioner")))
   (it "filters by namespace"
-    (expect (kele--fetch-resource-names "apps" "v1" "deployments"
+    (expect (kele--fetch-resource-names (kele--gvk-create
+                                         :group "apps"
+                                         :version "v1"
+                                         :kind "deployments")
                                         :namespace "kube-system"
                                         :context "kind-kele-test-cluster0")
             :to-have-same-items-as

--- a/tests/integration/test-integration.el
+++ b/tests/integration/test-integration.el
@@ -65,11 +65,13 @@
   (it "retrieves the resource as an alist"
     (async-wait (kele--cache-update kele--global-discovery-cache))
     (async-wait (kele--cache-update kele--global-kubeconfig-cache))
-    (setq retval (kele--get-resource "deployments" "coredns"
-                                                :group "apps"
-                                                :version "v1"
-                                                :context "kind-kele-test-cluster0"
-                                                :namespace "kube-system"))
+    (setq retval (kele--get-resource (kele--gvk-create
+                                      :kind "deployments"
+                                      :group "apps"
+                                      :version "v1")
+                                     "coredns"
+                                     :context "kind-kele-test-cluster0"
+                                     :namespace "kube-system"))
 
     (expect (kele--resource-container-p retval) :to-be-truthy)
     (expect (let-alist (kele--resource-container-resource retval) .metadata.name) :to-equal "coredns"))
@@ -77,11 +79,13 @@
   (it "returns an error if the resource is nonsense or does not exist"
     (async-wait (kele--cache-update kele--global-discovery-cache))
     (async-wait (kele--cache-update kele--global-kubeconfig-cache))
-    (expect (kele--get-resource "salaries" "mine"
-                                           :group "hello"
-                                           :version "v1"
-                                           :context "kind-kele-test-cluster0"
-                                           :namespace "kube-system")
+    (expect (kele--get-resource (kele--gvk-create
+                                 :kind "salaries"
+                                 :group "hello"
+                                 :version "v1")
+                                "mine"
+                                :context "kind-kele-test-cluster0"
+                                :namespace "kube-system")
             :to-throw 'kele-cache-lookup-error)))
 
 (describe "kele--proxy-process"

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -474,7 +474,9 @@ metadata:
   (describe "when GROUP and VERSION not specified"
     (describe "when only one group-version exists for the argument resource type"
       (it "auto-selects group-version"
-        (kele--get-resource "resourcequotas" "my-rq" :namespace "foobar")
+        (kele--get-resource (kele--gvk-create :kind "resourcequotas")
+                            "my-rq"
+                            :namespace "foobar")
         (expect 'plz :to-have-been-called-with
                 'get
                 "http://localhost:9999/api/v1/namespaces/foobar/resourcequotas/my-rq"
@@ -485,10 +487,11 @@ metadata:
       ;; disambiguate on users' behalf, present a completion buffer to users to
       ;; select, etc.
       (it "errors with the group-version options attached to the error"
-        (expect (kele--get-resource "ambiguousthings" "fake-name")
+        (expect (kele--get-resource (kele--gvk-create :kind "ambiguousthings")
+                                    "fake-name")
                 :to-throw 'kele-ambiguous-groupversion-error)
         (condition-case err
-            (kele--get-resource "ambiguousthings" "fake-name")
+            (kele--get-resource (kele--gvk-create :kind "ambiguousthings") "fake-name")
           (kele-ambiguous-groupversion-error
            (expect (cdr err) :to-have-same-items-as '("fake-group/v1"
                                                       "fake-other-group/v1")))

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -20,12 +20,6 @@
               '((foo . 1)
                 (bar . ((baz . 2))))))))
 
-(describe "kele--groupversion-string"
-  (it "properly handles 'core API', i.e. nil group"
-    (expect (kele--groupversion-string nil "v1") :to-equal "v1"))
-  (it "properly forms the group-version string"
-    (expect (kele--groupversion-string "apps" "v1") :to-equal "apps/v1")))
-
 (describe "kele--groupversion-split"
   (it "properly handles core API group-version strings"
     (expect (kele--groupversion-split "v1") :to-equal '(nil "v1")))
@@ -463,7 +457,8 @@ metadata:
               :to-throw 'user-error))
     (it "calls the right endpoint"
       (expect (kele--get-resource
-               "nodes" "my-node"
+               (kele--gvk-create :kind "nodes")
+               "my-node"
                :context "development")
               :not :to-throw)
       (expect 'plz :to-have-been-called-with
@@ -672,10 +667,25 @@ metadata:
       (kele--get-groupversion-arg)
       (expect 'completing-read :to-have-been-called))))
 
-(describe "kele--gvk-string"
-  (it "formats w/o group"
-    (expect (kele--gvk-string nil "v1" "Pod") :to-equal "v1.Pod"))
-  (it "formats w/ group"
-    (expect (kele--gvk-string "group" "v1" "Pod") :to-equal "group/v1.Pod")))
+(describe "kele--gvk"
+  (describe "kele--string"
+    (it "formats w/o group"
+      (expect (kele--string (kele--gvk-create
+                             :group nil
+                             :version "v1"
+                             :kind "Pod"))
+              :to-equal "v1.Pod"))
+    (it "formats w/ group"
+      (expect (kele--string (kele--gvk-create :group "group"
+                                              :version "v1"
+                                              :kind "Pod"))
+              :to-equal "group/v1.Pod")))
+  (describe "kele--gv-string"
+    (it "properly handles 'core API', i.e. nil group"
+      (expect (kele--gv-string (kele--gvk-create :group nil :version "v1"))
+              :to-equal "v1"))
+    (it "properly forms the group-version string"
+      (expect (kele--gv-string (kele--gvk-create :group "apps" :version "v1"))
+              :to-equal "apps/v1"))))
 
  ;;; test-kele.el ends here

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -670,15 +670,10 @@ metadata:
 (describe "kele--gvk"
   (describe "kele--string"
     (it "formats w/o group"
-      (expect (kele--string (kele--gvk-create
-                             :group nil
-                             :version "v1"
-                             :kind "Pod"))
+      (expect (kele--string (kele--gvk-create :version "v1" :kind "Pod"))
               :to-equal "v1.Pod"))
     (it "formats w/ group"
-      (expect (kele--string (kele--gvk-create :group "group"
-                                              :version "v1"
-                                              :kind "Pod"))
+      (expect (kele--string (kele--gvk-create :group "group" :version "v1" :kind "Pod"))
               :to-equal "group/v1.Pod")))
   (describe "kele--gv-string"
     (it "properly handles 'core API', i.e. nil group"

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -457,8 +457,9 @@ metadata:
 
   (describe "when resource is not namespaced"
     (it "errors when namespace is provided anyway"
-      (expect (kele--get-resource "nodes" "my-node"
-                                             :namespace "foobar")
+      (expect (kele--get-resource (kele--gvk-create :kind "nodes")
+                                  "my-node"
+                                  :namespace "foobar")
               :to-throw 'user-error))
     (it "calls the right endpoint"
       (expect (kele--get-resource


### PR DESCRIPTION
Having to pass three separate values around in slightly different semantics (plist? alist? group-version + kind args? group + version + kind args?) is getting cumbersome. This PR introduces a `gvk` struct that can be used as a singular value to pass around all the various functions.