### PR TITLE
Add function to look up arbitrary resource names in discovery cache

### DIFF
--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -330,6 +330,16 @@
     (it "sets the timer"
       (expect (oref cache timer) :to-equal :timer)))
 
+  (describe "kele--get-discovery-resource"
+    (before-each
+      (setq kele-cache-dir (f-expand "./tests/testdata/cache"))
+      (async-wait (kele--cache-update kele--global-discovery-cache)))
+
+    (it "fetches by kind"
+      (expect (kele--get-discovery-resource kele--global-discovery-cache
+      "AmbiguousThingFoo" :lookup-key 'kind)
+              :to-be-truthy)))
+
   (describe "kele--get-singular-for-plural"
     (before-each
       (setq kele-cache-dir (f-expand "./tests/testdata/cache"))


### PR DESCRIPTION
To implement #212, we need the ability to convert from the kind name, e.g. `Pod`, to the plural form, e.g. `pods`. This would be analogous to the existing `kele--get-singular-for-plural`, e.g. `kele--get-plural-for-kind`.

Since we'd rather not implement one function for each 2-permutation of singular/plural/kind, we generalize the existing `get-singular-for-plural` to allow for looking up a "discovery resource" by any given key within it. This will allow us to look up with, say, `singularName`, and use the retval to get the `kind`.