### PR TITLE
CI: Tweak ignore-error logic

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,20 +42,20 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install
       id: install
-      continue-on-error: ${{ matrix.ignore_error != '' && matrix.ignore_error }}
       run: |
         emacs --version
         cask build --verbose
         make compile
 
     - name: Run unit and static tests
-      if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
+      continue-on-error: ${{ matrix.ignore_error != '' && matrix.ignore_error }}
       run: |
         make testall
 
     - name: Setup integration test cluster
       id: kind
       uses: helm/kind-action@v1.4.0
+      continue-on-error: ${{ matrix.ignore_error != '' && matrix.ignore_error }}
       with:
         config: tests/test-cluster.yaml
         cluster_name: kele-test-cluster0
@@ -64,12 +64,15 @@ jobs:
     # See #69
     - name: Try populating discovery cache
       id: discovery
-      if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'
+      if: steps.kind.outcome == 'success'
+      continue-on-error: ${{ matrix.ignore_error != '' && matrix.ignore_error }}
       run: |
         kubectl -v=10 cluster-info
 
     - name: Run integration tests
-      if: steps.kind.outcome == 'success' && steps.kind.conclusion == 'success'
+      continue-on-error: ${{ matrix.ignore_error != '' && matrix.ignore_error }}
+      id: integration
+      if: steps.discovery.outcome == 'success'
       uses: nick-fields/retry@v2
       with:
         # at least one test is flaky. See #40
@@ -80,7 +83,7 @@ jobs:
           cask exec buttercup -L . tests/integration/
 
     - name: Upload coverage
-      if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
+      if: steps.integration.outcome == 'success' && steps.integration.conclusion == 'success'
       uses: codecov/codecov-action@v4
       with:
         env_vars: EMACS_VERSION


### PR DESCRIPTION
Currently "ignore error" simply means that installation failures,
e.g. byte-compilation errors, will be ignored. Tests still run in that case and
failed tests will fail CI.

Instead:

- We require installation to succeed unconditionally, even for ignore-error
matrix runs;
- We ignore error on test-run steps;
- We upload coverage only if all tests pass + the test-running succeeds
end-to-end