### PR TITLE
WIP: kind-aware port completion

### DIFF
--- a/kele.el
+++ b/kele.el
@@ -2086,7 +2086,7 @@ NAMESPACE and CONTEXT are used to identify the resource type to query for."
           (port (if (string-equal (oref resource kind) "services")
                     (completing-read "Port: "
                                      (-map (lambda (port-spec) (number-to-string (alist-get 'port port-spec)))
-                                           (kele--service-ports resource))
+                                           (kele--get-ports-for-resource resource))
                                      nil t)
                   (number-to-string (read-number "Port: ")))))
      (list context ns gvk name port)))
@@ -2137,7 +2137,10 @@ PORTS is used according to `completion-extra-properties'."
 (cl-defun kele--get-ports-for-resource (obj)
   "Get the exposed ports for the resource OBJ.
 
-OBJ must be a `kele--resource-container'."
+OBJ must be a `kele--resource-container'.
+
+Return value is a list of alists consisting of keys `name',
+`protocol', and `port'."
   (pcase (alist-get 'kind (oref obj resource))
     ("Service" (kele--service-ports obj))))
 

--- a/tests/unit/test-kele.el
+++ b/tests/unit/test-kele.el
@@ -744,8 +744,7 @@ metadata:
                                                                           (protocol . "TCP"))
                                                                          ((name . "foo")
                                                                           (containerPort . 9999)
-                                                                          (protocol
-                                                                           . "TCP"))))))))))))))))
+                                                                          (protocol . "TCP"))))))))))))))))
             :to-have-same-items-as
             (list '((name . "whatever") (port . 1234) (protocol . "TCP"))
                   '((name . "foo") (port . 5678) (protocol . "TCP")))))


### PR DESCRIPTION
Contributes to #240.

This PR implements the function `kele--get-ports-for-resource`, which is able to
retrieve the ports (for port-forwarding to) based on the passed-in kind.