### PR TITLE
kele-proxy was renamed to kele-ports

### DIFF
--- a/docs/references/changelog.md
+++ b/docs/references/changelog.md
@@ -28,6 +28,10 @@ versioning][semver].
 
 [server-side printing]: https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables
 
+### Fixed
+
+- Fixed `kele-transient` using non-existent `kele-proxy` instead of `kele-ports`
+
 ### Changed
 
 - Renamed `kele-after-context-switch-hook` to

--- a/kele.el
+++ b/kele.el
@@ -2281,7 +2281,7 @@ CONTEXT and NAMESPACE are used to identify where the deployment lives."
   ["Work with..."
    ("c" "Configurations" kele-config)
    ("r" "Resources" kele-resource)
-   ("p" "Proxy servers" kele-proxy)])
+   ("p" "Proxy servers" kele-ports)])
 
 (transient-define-suffix kele--toggle-proxy-current-context (context)
   :key "p"


### PR DESCRIPTION
This was omitted in https://github.com/jinnovation/kele.el/commit/e9d5e8f8d0564611d8e3395e983eb2fa4ad50305#diff-9b0f19a29ab7ebc7df908e39ba9e4c5555aaadba3626bc05cec337ee9457131aL2201-R2253

Closes #259